### PR TITLE
Fix for over-sized svgs issue

### DIFF
--- a/docs/css/solace-common.css
+++ b/docs/css/solace-common.css
@@ -219,7 +219,13 @@ aside .nav {
 
 .tutorials.learn .card-image {
     background: #9FB0BF;
-    position: relative
+    position: relative;
+    height: 200px;
+}
+
+.tutorials.learn .card-image .image {
+    height: calc( 100% * 2/3);
+    position: relative;
 }
 
 .tutorials .tutorial-description {
@@ -228,10 +234,10 @@ aside .nav {
 }
 
 .tutorials.learn .card-image img {
-    height: 200px;
+    height: 100%;
     margin: auto;
-    padding-bottom: 60px;
-    width: 100%
+    width: 100%;
+    position: absolute;
 }
 
 .tutorials .card {

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,8 +25,10 @@ layout: default
                             <div class="card">
                                 <a href="{{ site.baseurl }}{{ p.url }}"></a>
                                 <div class="card-image">
-                                    <img src="{{ site.baseurl }}/images/{{ p.icon }}" alt="{{ p.title }}"/>
-                                    <span class="card-title">{{ p.title }}</span>
+                                    <div class="image">
+                                      <img src="{{ site.baseurl }}/images/{{ p.icon }}" alt="{{ p.title }}" style="height:{{ p.icon-height }}; width:{{ p.icon-width }};"/>
+                                    </div>
+                                    <div class="card-title">{{ p.title }}</div>
                                 </div>
                                 <div class="card-content">
                                     <div class="tutorial-description">{{ p.summary }}</div>


### PR DESCRIPTION
Added support of passing in svg required dimensions as tutorial parameters
E.G.
            layout: tutorials
            title: Confirmed Delivery
            summary: Learn how to confirm that your messages are received by Solace Messaging.
            icon: I_dev_confirm.svg
            icon-height: 70px
            icon-width: 236px
